### PR TITLE
Add script for creating 'history' table

### DIFF
--- a/src/utils/history_table.ts
+++ b/src/utils/history_table.ts
@@ -1,0 +1,51 @@
+import { CreateTableCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { fromEnv } from '@aws-sdk/credential-providers'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const REGION = process.env.AWS_REGION || 'eu-west-2'
+const TABLE_NAME = process.env.DYNAMODB_HISTORY_TABLE_NAME || 'wb-api-history'
+
+const client = new DynamoDBClient({
+  region: REGION,
+  credentials: fromEnv()
+})
+
+const main = async () => {
+  const command = new CreateTableCommand({
+    TableName: TABLE_NAME,
+    AttributeDefinitions: [
+      {
+        AttributeName: 'userId',
+        AttributeType: 'S'
+      },
+      {
+        AttributeName: 'timestamp',
+        AttributeType: 'N'
+      }
+    ],
+    KeySchema: [
+      {
+        AttributeName: 'userId',
+        KeyType: 'HASH'
+      },
+      {
+        AttributeName: 'timestamp',
+        KeyType: 'RANGE'
+      }
+    ],
+    BillingMode: 'PAY_PER_REQUEST'
+  })
+
+  try {
+    const response = await client.send(command)
+    console.log(`Table "${TABLE_NAME}" created successfully:`, response)
+    return response
+  } catch (error) {
+    console.error('Error creating table:', error)
+    throw error
+  }
+}
+
+main()

--- a/src/utils/user_table.ts
+++ b/src/utils/user_table.ts
@@ -5,7 +5,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const REGION = process.env.AWS_REGION || 'eu-west-2'
-const TABLE_NAME = process.env.DYNAMODB_TABLE_NAME || 'wb-api-users'
+const TABLE_NAME = process.env.DYNAMODB_USER_TABLE_NAME || 'wb-api-users'
 
 const client = new DynamoDBClient({
   region: REGION,


### PR DESCRIPTION
## 📌 Summary
Adds a simple script for creating the 'history' DynamoDB table via AWS SDK

## 🏆 Related Issues
<!-- Link to the corresponding issue(s) -->
Closes #21 

## 🔗 Additional Notes
<!-- Any other relevant information -->
This PR also renames the `.env` variable storing the 'user" table name to enforce a consistent naming convention

A sort key of 'timestamp' is necessary for:

- automatically sorting any query results
- allow for querying of specific time ranges, such as a user's search history between two dates