### PR TITLE
Chore/alter history table

### DIFF
--- a/src/utils/history_table.ts
+++ b/src/utils/history_table.ts
@@ -17,7 +17,7 @@ const main = async () => {
     TableName: TABLE_NAME,
     AttributeDefinitions: [
       {
-        AttributeName: 'userId',
+        AttributeName: 'accessToken',
         AttributeType: 'S'
       },
       {
@@ -27,7 +27,7 @@ const main = async () => {
     ],
     KeySchema: [
       {
-        AttributeName: 'userId',
+        AttributeName: 'accessToken',
         KeyType: 'HASH'
       },
       {

--- a/src/utils/history_table.ts
+++ b/src/utils/history_table.ts
@@ -22,7 +22,7 @@ const main = async () => {
       },
       {
         AttributeName: 'timestamp',
-        AttributeType: 'N'
+        AttributeType: 'S'
       }
     ],
     KeySchema: [


### PR DESCRIPTION
## 📌 Summary
Changes the partition key for the history table to 'accessToken' to allow for easier retrieval of a user's search history

## 🏆 Related Issues
<!-- Link to the corresponding issue(s) -->
N/A

## 🔗 Additional Notes
<!-- Any other relevant information -->
N/A